### PR TITLE
Initialize Next.js scaffold and Tailwind setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+}

--- a/package.json
+++ b/package.json
@@ -1,16 +1,22 @@
 {
   "name": "demo-franchise-u",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "commonjs",
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
   "devDependencies": {
-    "@tailwindcss/forms": "^0.5.3"
+    "@tailwindcss/forms": "^0.5.3",
+    "tailwindcss": "latest",
+    "postcss": "latest",
+    "autoprefixer": "latest"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,7 @@
+import '../styles/globals.css'
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+export default MyApp

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,9 @@
+export default function Home() {
+  return (
+    <div className="p-8 m-8">
+      <h1 className="text-2xl font-bold mb-4">Welcome to Next.js!</h1>
+      <p className="text-secondary mb-4">This is a demo Next.js + Tailwind CSS app.</p>
+      <button className="px-4 py-2 bg-accent text-black rounded">Accent Button</button>
+    </div>
+  )
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-white text-primary;
+}
+
+header {
+  @apply text-primary;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [],
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: '#AD0000',
+        black: '#000000',
+        white: '#FFFFFF',
+        secondary: '#8B9DA1',
+        accent: '#FEBE10',
+      },
+    },
   },
   plugins: [require('@tailwindcss/forms')],
 }


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js app structure
- add Tailwind CSS config with brand colors
- define global styles for default background and header color
- demonstrate accent and spacing classes on home page
- ignore node build output

## Testing
- `npx create-next-app@latest` *(fails: 403 Forbidden)*
- `npm install -D tailwindcss postcss autoprefixer` *(fails: 403 Forbidden)*
- `npx tailwindcss init -p` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68485f7290c4832698919f8f918176c1